### PR TITLE
Remove call to Config and use Rails.configuration instead

### DIFF
--- a/lib/tanoshimu_utils/concerns/resource_fetch.rb
+++ b/lib/tanoshimu_utils/concerns/resource_fetch.rb
@@ -24,7 +24,7 @@ module TanoshimuUtils
             attachment = resource_for(resource_name).attachment
             return default_url if attachment.nil?
 
-            if Config.uses_disk_storage?
+            if Rails.configuration.uses_disk_storage
               Rails.application.routes.url_helpers.rails_blob_url(attachment, only_path: true)
             else
               attachment.service_url(expires_in: expiry)


### PR DESCRIPTION
Replace `Config.uses_disk_storage?` (which was project-depend) to use `Rails.configuration.uses_disk_storage` (which will be defined the Rails project's `config/application.rb` as `config.uses_disk_storage`)

We recommend:
```ruby
module YourApplication
  ..
  config.uses_disk_storage = Rails.env.development?
  ..
end
```